### PR TITLE
Fix for Angular 5

### DIFF
--- a/src/angular2-jwt-refresh.ts
+++ b/src/angular2-jwt-refresh.ts
@@ -20,11 +20,10 @@ import {
   IAuthConfig,
   JwtHelper
 } from 'angular2-jwt';
-import 'rxjs';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 import { Subject } from 'rxjs/Subject';
-
+import 'rxjs/add/observable/of';
 
 @Injectable()
 export class JwtHttp extends AuthHttp {


### PR DESCRIPTION
I am only not sure if this is due to a new version of Angular, or due to a newer version of RxJS which Angular 5 forces.
However, it produces an error in production if one doesn't import operators separately and it is also advised not to import the whole rxjs module (`import 'rxjs';`), because it simply bloats the final output and it may not be reduced in three-shaking.